### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -52,13 +52,13 @@ export const getAllDocsCategories = () => {
 };
 
 export const getMdxBySlug = async (basePath: string, slug: string) => {
-  const mdxPath = path.join(DATA_PATH, basePath, `${slug}.mdx`);
+  // Construct and resolve the path to prevent path traversal
+  const mdxPath = path.resolve(DATA_PATH, basePath, `${slug}.mdx`);
+  // Ensure the resolved path is within DATA_PATH
+  if (!mdxPath.startsWith(DATA_PATH + path.sep)) return;
   if (!fs.existsSync(mdxPath)) return;
 
-  const source = fs.readFileSync(
-    path.join(DATA_PATH, basePath, `${slug}.mdx`),
-    "utf8",
-  );
+  const source = fs.readFileSync(mdxPath, "utf8");
 
   const { frontmatter, code } = await bundleMDX({ source });
 


### PR DESCRIPTION
Potential fix for [https://github.com/phantomstudios/css-components-website/security/code-scanning/2](https://github.com/phantomstudios/css-components-website/security/code-scanning/2)

To fix the problem, we need to ensure that the constructed file path always stays within the intended `DATA_PATH` directory and cannot be manipulated to access files outside of it. The best way to do this is to resolve the constructed path and check that it starts with the intended root directory. Specifically, after constructing the path with `path.join`, we should use `path.resolve` to normalize it, and then check that the resolved path starts with `DATA_PATH`. If it does not, we should return early or throw an error. This check should be added in both places where the path is constructed and used: line 55 (for the existence check) and line 59 (for reading the file). Alternatively, we can construct the path once, validate it, and then use it for both checks.

We do not need to add any new dependencies, as Node's built-in `path` and `fs` modules are sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
